### PR TITLE
Bug fixes for structs and sizeof()

### DIFF
--- a/smallC/defs.h
+++ b/smallC/defs.h
@@ -30,6 +30,7 @@ struct symbol {
     int storage;            /* public, auto, extern, static, lstatic, defauto*/
     int offset;             /* offset*/
     int tagidx;             /* index of struct in tag table*/
+    int struct_size;        /* the size, in bytes, of a member of a struct - only used for member declarations */
 };
 #define SYMBOL struct symbol
 

--- a/smallC/expr.c
+++ b/smallC/expr.c
@@ -635,7 +635,13 @@ hier10 (LVALUE *lval) {
         inbyte();
         k = hier10 (lval);
         if ((k & FETCH) == 0) {
-            error ("illegal address");
+            /* Without this check, this error triggers when trying to
+             * evaluate a struct's address (a legal operation). Because
+             * structs are stored as an address, nothing more than not
+             * erroring is needed to load their address. */
+            if (lval->symbol->type != STRUCT){
+                error ("illegal address");
+            }
             return (0);
         }
         ptr = lval->symbol;

--- a/smallC/lex.c
+++ b/smallC/lex.c
@@ -221,6 +221,9 @@ int get_type() {
         return CCHAR;
     } else if (amatch ("int", 3)) {
         return CINT;
+    /* recognize structs being passed as a proper type */
+    } else if (amatch ("struct", 6)) {
+        return STRUCT;
     }
     return 0;
 }

--- a/smallC/main.c
+++ b/smallC/main.c
@@ -381,24 +381,33 @@ dump_struct(SYMBOL *symbol, int position) {
     newline();
     for (i=0; i<number_of_members; i++) {
         /* i is the index of current member, get type */
-        int member_type = member_table[
-            tag_table[symbol->tagidx].member_idx + i].type;
-
-        if (member_type & CINT) {
-            gen_def_word();
-        } else {
-            gen_def_byte();
+        SYMBOL member = member_table[
+            tag_table[symbol->tagidx].member_idx + i];
+        /* array members need proper storage space (the compiler currently
+         * doesn't allow arrays in structs to be initilized */
+        if(member.identity == ARRAY){
+            gen_def_storage();
+            output_number(member.struct_size);
+            newline();
         }
-        if (position < get_size(symbol->name)) {
-            /* dump data */
-            value = get_item_at(symbol->name, position*number_of_members+i,
-                &tag_table[symbol->tagidx]);
-            output_number(value);
-        } else {
-            /* dump zero, no more data available */
-            output_number(0);
+		else{
+            /* both pointers and ints take two bytes */
+            if (member.type & CINT || member.identity == POINTER) {
+                gen_def_word();
+            } else {
+                gen_def_byte();
+            }
+            if (position < get_size(symbol->name)) {
+                /* dump data */
+                value = get_item_at(symbol->name, position*number_of_members+i,
+                    &tag_table[symbol->tagidx]);
+                output_number(value);
+            } else {
+                /* dump zero, no more data available */
+                output_number(0);
+            }
+            newline();
         }
-        newline();
     }
 }
 

--- a/smallC/struct.c
+++ b/smallC/struct.c
@@ -53,7 +53,7 @@ SYMBOL *find_member(TAG_SYMBOL *tag, char *sname) {
  * @param storage
  * @return
  */
-add_member(char *sname, char identity, char type, int offset, int storage_class) {
+add_member(char *sname, char identity, char type, int offset, int storage_class, int member_size) {
     char *buffer_ptr;
     SYMBOL *symbol;
     if (member_table_index >= NUMMEMB) {
@@ -67,6 +67,8 @@ add_member(char *sname, char identity, char type, int offset, int storage_class)
     symbol->type = type;
     symbol->storage = storage_class;
     symbol->offset = offset;
+    /* set size for arrays */
+    symbol->struct_size = member_size;
 
     member_table_index++;
 }

--- a/smallC/sym.c
+++ b/smallC/sym.c
@@ -246,9 +246,18 @@ declare_local(int typ, int stclass, int otag) {
             }
             if (stclass != LSTATIC) {
                 stkp = gen_modify_stack(stkp - k);
-                add_local(sname, j, typ, stkp, AUTO);
-            } else
-                add_local(sname, j, typ, k, LSTATIC);
+                /* local structs need their tagidx set */
+                current_symbol_table_idx = add_local(sname, j, typ, stkp, AUTO);
+                if(typ == STRUCT) {
+                    symbol_table[current_symbol_table_idx].tagidx = otag;
+                }
+            } else {
+                /* local structs need their tagidx set */
+                current_symbol_table_idx = add_local(sname, j, typ, k, LSTATIC);
+                if(typ == STRUCT) {
+                    symbol_table[current_symbol_table_idx].tagidx = otag;
+                }
+            }
             break;
         }
         if (!match(","))

--- a/smallC/sym.c
+++ b/smallC/sym.c
@@ -53,7 +53,7 @@ declare_global(int type, int storage, TAG_SYMBOL *mtag, int otag, int is_struct)
                 break;
             } else if (is_struct) {
                 /* structure member, mtag->size is offset */
-                add_member(sname, identity, type, mtag->size, storage);
+                add_member(sname, identity, type, mtag->size, storage, (type & CINT) ? dim*INTSIZE : dim);
                 /* store (correctly scaled) size of member in tag table entry */
                 if (identity == POINTER)
                     type = CINT;
@@ -62,7 +62,7 @@ declare_global(int type, int storage, TAG_SYMBOL *mtag, int otag, int is_struct)
             }
             else {
                 /* union member, offset is always zero */
-                add_member(sname, identity, type, 0, storage);
+                add_member(sname, identity, type, 0, storage, (type & CINT) ? dim*INTSIZE : dim);
                 /* store maximum member size in tag table entry */
                 if (identity == POINTER)
                     type = CINT;


### PR DESCRIPTION
More details about each change are in the commit messages and descriptions.

These changes do four main things:
1. Properly set locally declared struct's tagidx property, which was previously not set for local structs.
2. Allow struct pointers to be passed to functions.
3. Properly dump global structs containing pointers and arrays.
4. Allow sizeof() to be used on unsigned types, pointers, and struct types.

I have tried to test all the changes to ensure proper behavior.