### PR TITLE
Error messages formatted to 'gcc' style

### DIFF
--- a/smallC/data.h
+++ b/smallC/data.h
@@ -16,6 +16,8 @@ extern  int     macptr;
 extern  char    line[];
 extern  char    mline[];
 extern  int     lptr, mptr;
+extern  int     srcln;
+extern  char *  finame;
 
 extern TAG_SYMBOL  tag_table[NUMTAG]; /* start of structure tag table */
 extern int     tag_table_index;   /* ptr to next entry */

--- a/smallC/data.h
+++ b/smallC/data.h
@@ -18,6 +18,8 @@ extern  char    mline[];
 extern  int     lptr, mptr;
 extern  int     srcln;
 extern  char *  finame;
+extern  int     srclni[];
+extern  char    finamei[INCLSIZ][20];
 
 extern TAG_SYMBOL  tag_table[NUMTAG]; /* start of structure tag table */
 extern int     tag_table_index;   /* ptr to next entry */

--- a/smallC/data.h
+++ b/smallC/data.h
@@ -16,10 +16,8 @@ extern  int     macptr;
 extern  char    line[];
 extern  char    mline[];
 extern  int     lptr, mptr;
-extern  int     srcln;
-extern  char *  finame;
-extern  int     srclni[];
-extern  char    finamei[INCLSIZ][20];
+extern  char    finame[INCLSIZ+1][20]; /* global input filenames for error messages */
+extern  int     srcln[]; /* source file line counters for error messages */
 
 extern TAG_SYMBOL  tag_table[NUMTAG]; /* start of structure tag table */
 extern int     tag_table_index;   /* ptr to next entry */

--- a/smallC/error.c
+++ b/smallC/error.c
@@ -7,7 +7,6 @@
 #include "defs.h"
 #include "data.h"
 
-int srcln=0;
 
 error (ptr)
 char    ptr[];
@@ -24,10 +23,17 @@ char    ptr[];
 
 doerror(ptr) char *ptr; {
         int k;
-	if(finame)
-          output_string (finame);
-	output_string (":");
-	output_decimal(srcln);
+	if(inclsp == 0){
+		if(finame)
+          		output_string (finame);
+		output_string (":");
+		output_decimal(srcln);
+	}
+	else{
+          	output_string (finamei[inclsp-1]);
+		output_string (":");
+		output_decimal(srclni[inclsp-1]);
+	}
 	output_string (":");
 	output_decimal(lptr);
 	output_string (": error: ");

--- a/smallC/error.c
+++ b/smallC/error.c
@@ -26,15 +26,15 @@ doerror(ptr) char *ptr; {
         int k;
 	if(finame)
           output_string (finame);
-        output_string (":");
+	output_string (":");
 	output_decimal(srcln);
-        output_string (":");
+	output_string (":");
 	output_decimal(lptr);
-        output_string (": error: ");
-        output_string (ptr);
-        newline ();
+	output_string (": error: ");
+	output_string (ptr);
+	newline ();
 	output_string (line);
-        newline ();
+	newline ();
         k = 0;
         while (k < lptr) {
                 if (line[k] == 9)

--- a/smallC/error.c
+++ b/smallC/error.c
@@ -7,6 +7,8 @@
 #include "defs.h"
 #include "data.h"
 
+int srcln=0;
+
 error (ptr)
 char    ptr[];
 {
@@ -22,10 +24,17 @@ char    ptr[];
 
 doerror(ptr) char *ptr; {
         int k;
-        gen_comment ();
-        output_string (line);
+	if(finame)
+          output_string (finame);
+        output_string (":");
+	output_decimal(srcln);
+        output_string (":");
+	output_decimal(lptr);
+        output_string (": error: ");
+        output_string (ptr);
         newline ();
-        gen_comment ();
+	output_string (line);
+        newline ();
         k = 0;
         while (k < lptr) {
                 if (line[k] == 9)
@@ -35,11 +44,6 @@ doerror(ptr) char *ptr; {
                 k++;
         }
         output_byte ('^');
-        newline ();
-        gen_comment ();
-        output_string ("******  ");
-        output_string (ptr);
-        output_string ("  ******");
         newline ();
 }
 

--- a/smallC/error.c
+++ b/smallC/error.c
@@ -23,19 +23,12 @@ char    ptr[];
 
 doerror(ptr) char *ptr; {
         int k;
-	if(inclsp == 0){
-		if(finame)
-          		output_string (finame);
-		output_string (":");
-		output_decimal(srcln);
-	}
-	else{
-          	output_string (finamei[inclsp-1]);
-		output_string (":");
-		output_decimal(srclni[inclsp-1]);
-	}
+	if(finame[inclsp]) /* print actual source filename */
+        	output_string (finame[inclsp]);
 	output_string (":");
-	output_decimal(lptr);
+	output_decimal(srcln[inclsp]); /* print source line number*/
+	output_string (":");
+	output_decimal(lptr); /* print column number */ 
 	output_string (": error: ");
 	output_string (ptr);
 	newline ();

--- a/smallC/io.c
+++ b/smallC/io.c
@@ -102,6 +102,7 @@ readline () {
                         line[lptr++] = k;
                 }
                 line[lptr] = 0;
+		srcln++;
                 if (k <= 0)
                         if (input2 != NULL) {
                                 input2 = inclstk[--inclsp];

--- a/smallC/io.c
+++ b/smallC/io.c
@@ -102,8 +102,12 @@ readline () {
                         line[lptr++] = k;
                 }
                 line[lptr] = 0;
-		if(unit == input)
-		  srcln++;
+		if(inclsp == 0){
+			srcln++;
+		}
+		else{
+			srclni[inclsp-1]++;
+		}
                 if (k <= 0)
                         if (input2 != NULL) {
                                 input2 = inclstk[--inclsp];

--- a/smallC/io.c
+++ b/smallC/io.c
@@ -102,7 +102,8 @@ readline () {
                         line[lptr++] = k;
                 }
                 line[lptr] = 0;
-		srcln++;
+		if(unit == input)
+		  srcln++;
                 if (k <= 0)
                         if (input2 != NULL) {
                                 input2 = inclstk[--inclsp];

--- a/smallC/io.c
+++ b/smallC/io.c
@@ -102,12 +102,7 @@ readline () {
                         line[lptr++] = k;
                 }
                 line[lptr] = 0;
-		if(inclsp == 0){
-			srcln++;
-		}
-		else{
-			srclni[inclsp-1]++;
-		}
+		srcln[inclsp]++; /* increment source line number of actual file */
                 if (k <= 0)
                         if (input2 != NULL) {
                                 input2 = inclstk[--inclsp];

--- a/smallC/main.c
+++ b/smallC/main.c
@@ -11,6 +11,10 @@
 FILE *logFile = NULL;
 
 char * finame = NULL;
+char finamei [INCLSIZ][20];
+
+int srcln=0;
+int srclni[INCLSIZ]={0,0,0};
 
 /* Simple oputs function to replace the ugly fputs(foo, stdout) */
 

--- a/smallC/main.c
+++ b/smallC/main.c
@@ -10,6 +10,8 @@
 
 FILE *logFile = NULL;
 
+char * finame = NULL;
+
 /* Simple oputs function to replace the ugly fputs(foo, stdout) */
 
 void oputs(char *str)
@@ -124,6 +126,8 @@ main(int argc, char *argv[]) {
  * @return
  */
 compile(char *file) {
+    finame=file;
+    srcln=0;
     if (file == NULL || filename_typeof(file) == 'c') {
         global_table_index = 0;
         local_table_index = NUMBER_OF_GLOBALS;

--- a/smallC/main.c
+++ b/smallC/main.c
@@ -10,11 +10,9 @@
 
 FILE *logFile = NULL;
 
-char * finame = NULL;
-char finamei [INCLSIZ][20];
+char finame [INCLSIZ+1][20];  /* global input filenames for error messages */
 
-int srcln=0;
-int srclni[INCLSIZ]={0,0,0};
+int srcln[INCLSIZ+1]={0,0,0,0}; /* source file line counters for error messages */
 
 /* Simple oputs function to replace the ugly fputs(foo, stdout) */
 
@@ -130,8 +128,8 @@ main(int argc, char *argv[]) {
  * @return
  */
 compile(char *file) {
-    finame=file;
-    srcln=0;
+    strcpy(finame[0],file); /* copy actual filename to filename array */
+    srcln[0]=0; /* reset source line counter*/
     if (file == NULL || filename_typeof(file) == 'c') {
         global_table_index = 0;
         local_table_index = NUMBER_OF_GLOBALS;

--- a/smallC/preproc.c
+++ b/smallC/preproc.c
@@ -35,7 +35,8 @@ FILE* fix_include_name () {
                 strcpy(buf2, DEFLIB);
                 strcat(buf2, buf);
                 fp = fopen(buf2, "r");
-		strcpy(finamei[inclsp],buf2);
+		strcpy(finame[inclsp+1],buf2); /* copy include filename to filename array*/
+    		srcln[inclsp+1]=0; /* reset source line counter*/
         }
         return (fp);
 }

--- a/smallC/preproc.c
+++ b/smallC/preproc.c
@@ -35,6 +35,7 @@ FILE* fix_include_name () {
                 strcpy(buf2, DEFLIB);
                 strcat(buf2, buf);
                 fp = fopen(buf2, "r");
+		strcpy(finamei[inclsp],buf2);
         }
         return (fp);
 }


### PR DESCRIPTION
Changes to make error messages format like to 'gcc' style. 
This new format can be used with text editor (like vim) with error detection support.  
Old error format:
```
../scc8080 -t teste.c
; value=2;
;      ^
;******  undeclared variable  ******
; value=2;
;       ^
;******  must be lvalue  ******
; value=2;
;       ^
;******  missing semicolon  ******

Error(s)
```
New error format:
```
../scc8080 -t teste.c
teste.c:25:6: error: undeclared variable
 value=2;
      ^
teste.c:25:7: error: must be lvalue
 value=2;
       ^
teste.c:25:7: error: missing semicolon
 value=2;
       ^

Error(s)
```
